### PR TITLE
add self-hosted coverage badge system

### DIFF
--- a/.github/workflows/coverage-badge.yml
+++ b/.github/workflows/coverage-badge.yml
@@ -1,0 +1,72 @@
+name: Update Coverage Badge
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  update-coverage-badge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+    
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements-test.txt
+    
+    - name: Run tests and generate coverage
+      run: make coverage
+    
+    - name: Extract coverage percentage
+      run: |
+        COVERAGE=$(coverage report | tail -1 | awk '{print $4}' | sed 's/%//')
+        echo "COVERAGE=$COVERAGE" >> $GITHUB_ENV
+        echo "Coverage: $COVERAGE%"
+    
+    - name: Update coverage badge via API
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        # Create badge content
+        BADGE_CONTENT='{"schemaVersion": 1, "label": "coverage", "message": "'$COVERAGE'%", "color": "brightgreen"}'
+        
+        # Get current file SHA if it exists
+        SHA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+          "https://api.github.com/repos/${{ github.repository }}/contents/.github/badges/coverage.json" \
+          | python -c "import sys, json; data = json.load(sys.stdin); print(data.get('sha', ''))" 2>/dev/null || echo "")
+        
+        # Create or update file via GitHub API
+        if [ -n "$SHA" ]; then
+          # File exists, update it
+          curl -X PUT \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"message\": \"Update coverage badge [skip ci]\",
+              \"content\": \"$(echo -n "$BADGE_CONTENT" | base64 -w 0)\",
+              \"sha\": \"$SHA\"
+            }" \
+            "https://api.github.com/repos/${{ github.repository }}/contents/.github/badges/coverage.json"
+        else
+          # File doesn't exist, create it
+          curl -X PUT \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{
+              \"message\": \"Create coverage badge [skip ci]\",
+              \"content\": \"$(echo -n "$BADGE_CONTENT" | base64 -w 0)\"
+            }" \
+            "https://api.github.com/repos/${{ github.repository }}/contents/.github/badges/coverage.json"
+        fi 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # JIRA Extractor
 
 ![PR Check](https://github.com/jewzaam/jira-extractor/workflows/PR%20Check/badge.svg)
+[![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jewzaam/jira-extractor/main/.github/badges/coverage.json)](https://github.com/jewzaam/jira-extractor/actions/workflows/coverage-badge.yml)
 
 A command-line tool for extracting JIRA issues and related issues with configurable export options and relationship traversal.
 


### PR DESCRIPTION
- Created GitHub Actions workflow to generate coverage badges
- Workflow runs on main branch pushes, uses make coverage
- Updates badge JSON file via GitHub API with [skip ci]
- Updated README to use endpoint-based coverage badge
- Badge links to coverage workflow for transparency
- No external dependencies required


Assisted-by: Cursor (Claude)