### PR TITLE
Add relationship discovery tools for JIRA issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,11 @@ Configure the server in your VS Code MCP settings:
 
 ## Available Tools
 
-The server provides three MCP tools:
+The server provides seven MCP tools:
 
-### 1. `search_issues`
+### Basic Tools
+
+#### 1. `search_issues`
 Search for JIRA issues using JQL or simple text queries.
 
 **Parameters:**
@@ -175,7 +177,7 @@ Search for JIRA issues using JQL or simple text queries.
 - Simple text: `"bug in authentication"`
 - JQL query: `"project = PROJ AND status = Open"`
 
-### 2. `get_issue` 
+#### 2. `get_issue` 
 Retrieve detailed information about a specific JIRA issue.
 
 **Parameters:**
@@ -186,12 +188,90 @@ Retrieve detailed information about a specific JIRA issue.
 - Get issue: `"PROJ-123"`
 - With expansion: `"PROJ-123"` with expand `"changelog,comments"`
 
-### 3. `identifier_hint`
+#### 3. `identifier_hint`
 Get help about JIRA issue identifier format.
 
 **Parameters:** None
 
 **Returns:** Description of valid JIRA issue key patterns.
+
+### Relationship Discovery Tools
+
+#### 4. `get_issue_relationships`
+Get comprehensive relationship information for a specific JIRA issue.
+
+**Parameters:**
+- `issue_key` (string): JIRA issue key (e.g., "PROJ-123")
+
+**Returns:** Complete relationship data including:
+- Parent issue (for subtasks)
+- List of subtask keys
+- Issue links with type and direction
+- Count of remote links
+
+#### 5. `get_descendants`
+Get all descendants of an issue based on relationship types and traversal depth.
+
+**Parameters:**
+- `issue_key` (string): Root JIRA issue key
+- `max_depth` (int, optional): Maximum traversal depth (-1 for unlimited, default: 3)
+- `include_subtasks` (bool, optional): Include subtask relationships (default: true)
+- `include_links` (bool, optional): Include issue links (default: true)
+- `include_parent_links` (bool, optional): Include custom parent-link fields (default: false)
+
+**Returns:** Tree structure with all descendant issues and traversal metadata.
+
+#### 6. `get_children`
+Get direct children of an issue (subtasks and optionally parent-link children).
+
+**Parameters:**
+- `issue_key` (string): Parent JIRA issue key
+- `include_parent_links` (bool, optional): Include custom parent-link children (default: false)
+- `parent_link_field` (string, optional): Name of parent link field (default: "Parent Link")
+
+**Returns:** List of immediate child issues.
+
+#### 7. `get_linked_issues`
+Get issues linked to the specified issue via JIRA issue links.
+
+**Parameters:**
+- `issue_key` (string): JIRA issue key
+- `link_type` (string, optional): Filter by specific link type (case-insensitive)
+
+**Returns:** List of linked issues with link type, direction, and relationship details.
+
+#### 8. `get_parent`
+Get the immediate parent of a JIRA issue.
+
+**Parameters:**
+- `issue_key` (string): JIRA issue key
+- `include_parent_links` (boolean, optional): Include custom parent link fields (default: true)
+- `parent_link_field` (string, optional): Name of parent link field (default: "Parent Link")
+
+**Returns:** Parent information including parent key, summary, and relationship type.
+
+**Example:**
+```
+get_parent("PROJ-123")
+# Returns: ParentInfo with parent_key, parent_summary, parent_type
+```
+
+#### 9. `get_ancestors`
+Get all ancestors of a JIRA issue by following parent relationships recursively.
+
+**Parameters:**
+- `issue_key` (string): JIRA issue key  
+- `max_depth` (int, optional): Maximum traversal depth (-1 for unlimited, default: 5)
+- `include_parent_links` (boolean, optional): Include custom parent link fields (default: true)
+- `parent_link_field` (string, optional): Name of parent link field (default: "Parent Link")
+
+**Returns:** Tree structure with all ancestor issues, traversal order, and metadata.
+
+**Example:**
+```
+get_ancestors("PROJ-123", max_depth=3)
+# Returns: AncestorTree with ancestors list, traversal_order, and metadata
+```
 
 ## Development
 

--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -1,6 +1,6 @@
 # MCP JIRA Server Test Plan
 
-This document maps 1:1 to unit tests in the codebase. Each test item corresponds to a specific test method for the MCP JIRA server.
+This document maps 1:1 to unit tests in the codebase. Each test item corresponds to a specific test method for the MCP JIRA server.  Validation is done by a human, checking that implementation meets intent of the test, not just technically the literal interpretation of the description.
 
 ## CONFIG - Configuration Management
 
@@ -33,6 +33,30 @@ This document maps 1:1 to unit tests in the codebase. Each test item corresponds
 | TOOLS-09 | Get issue with expand parameter | |
 | TOOLS-10 | Get issue returns proper IssueDetails object | |
 | TOOLS-11 | Identifier hint returns expected format description | |
+| TOOLS-12 | Get issue relationships with all relationship types | |
+| TOOLS-13 | Get issue relationships with no relationships | |
+| TOOLS-14 | Get issue relationships link parsing | |
+| TOOLS-15 | Get descendants basic functionality | |
+| TOOLS-16 | Get descendants excludes root issue from results | |
+| TOOLS-17 | Get descendants with custom parameters | |
+| TOOLS-18 | Get children with subtasks only | |
+| TOOLS-19 | Get children with parent links enabled | |
+| TOOLS-20 | Get children handles parent link fetch errors gracefully | |
+| TOOLS-21 | Get linked issues returns all links | |
+| TOOLS-22 | Get linked issues with link type filter | |
+| TOOLS-23 | Get linked issues with case-insensitive filter | |
+| TOOLS-24 | Get linked issues with no matching links | |
+| TOOLS-25 | Get linked issues handles missing or malformed link data | |
+| TOOLS-26 | Get parent with subtask parent relationship | |
+| TOOLS-27 | Get parent with no parent relationship | |
+| TOOLS-28 | Get parent with custom parent link field | |
+| TOOLS-29 | Get parent with parent link field containing value | |
+| TOOLS-30 | Get ancestors with single level hierarchy | |
+| TOOLS-31 | Get ancestors with multi-level hierarchy | |
+| TOOLS-32 | Get ancestors with depth limit | |
+| TOOLS-33 | Get ancestors for issue with no parents | |
+| TOOLS-34 | Get ancestors handles parent fetch errors gracefully | |
+| TOOLS-35 | Get ancestors prevents infinite loops from cycles | |
 
 ## SERVER - MCP Server Creation and Configuration
 
@@ -43,7 +67,7 @@ This document maps 1:1 to unit tests in the codebase. Each test item corresponds
 | SERVER-03 | Create server with username/token auth | |
 | SERVER-04 | Create server with bearer token auth | |
 | SERVER-05 | Server has correct name and instructions | |
-| SERVER-06 | Server registers all three tools | |
+| SERVER-06 | Server registers all nine tools | |
 | SERVER-07 | Tools have correct annotations (read-only, idempotent) | |
 
 ## CLI - Command Line Interface

--- a/mcp_jira_server/server.py
+++ b/mcp_jira_server/server.py
@@ -78,6 +78,208 @@ class IssueDetails(BaseModel):
     }
 
 
+class ProjectSummary(BaseModel):
+    """Basic information about a JIRA project."""
+    
+    key: str = Field(..., title="Project key", examples=["PROJ"])
+    name: str = Field(..., title="Project name")
+    project_type: str = Field(..., title="Project type", examples=["software"])
+    lead: Optional[str] = Field(None, title="Project lead username")
+    url: str = Field(..., title="Direct URL to the project")
+
+    model_config = {
+        "title": "ProjectSummary",
+        "extra": "ignore",
+    }
+
+
+class ProjectDetails(BaseModel):
+    """Detailed information about a JIRA project."""
+    
+    key: str = Field(..., title="Project key")
+    name: str = Field(..., title="Project name")
+    description: Optional[str] = Field(None, title="Project description")
+    project_type: str = Field(..., title="Project type")
+    lead: Optional[str] = Field(None, title="Project lead username")
+    url: str = Field(..., title="Direct URL to the project")
+    raw: Dict[str, Any] = Field(..., title="Full unmodified JIRA API response")
+
+    model_config = {
+        "title": "ProjectDetails",
+        "extra": "ignore",
+    }
+
+
+class FieldInfo(BaseModel):
+    """Information about a JIRA field."""
+    
+    id: str = Field(..., title="Field ID")
+    name: str = Field(..., title="Field name")
+    custom: bool = Field(..., title="Whether this is a custom field")
+    schema_type: Optional[str] = Field(None, title="Field data type")
+    
+    model_config = {
+        "title": "FieldInfo", 
+        "extra": "ignore",
+    }
+
+
+class IssueType(BaseModel):
+    """Information about a JIRA issue type."""
+    
+    id: str = Field(..., title="Issue type ID")
+    name: str = Field(..., title="Issue type name", examples=["Bug", "Story"])
+    description: Optional[str] = Field(None, title="Issue type description")
+    subtask: bool = Field(..., title="Whether this is a subtask type")
+    
+    model_config = {
+        "title": "IssueType",
+        "extra": "ignore",
+    }
+
+
+class StatusInfo(BaseModel):
+    """Information about a JIRA status."""
+    
+    id: str = Field(..., title="Status ID")
+    name: str = Field(..., title="Status name", examples=["Open", "In Progress"])
+    description: Optional[str] = Field(None, title="Status description")
+    category: Optional[str] = Field(None, title="Status category", examples=["To Do", "In Progress", "Done"])
+    
+    model_config = {
+        "title": "StatusInfo",
+        "extra": "ignore",
+    }
+
+
+class Priority(BaseModel):
+    """Information about a JIRA priority."""
+    
+    id: str = Field(..., title="Priority ID")
+    name: str = Field(..., title="Priority name", examples=["High", "Medium", "Low"])
+    description: Optional[str] = Field(None, title="Priority description")
+    
+    model_config = {
+        "title": "Priority",
+        "extra": "ignore",
+    }
+
+
+class UserInfo(BaseModel):
+    """Information about a JIRA user."""
+    
+    username: str = Field(..., title="Username")
+    display_name: str = Field(..., title="Display name")
+    email: Optional[str] = Field(None, title="Email address")
+    active: bool = Field(..., title="Whether user is active")
+    
+    model_config = {
+        "title": "UserInfo",
+        "extra": "ignore",
+    }
+
+
+class Comment(BaseModel):
+    """Information about a JIRA issue comment."""
+    
+    id: str = Field(..., title="Comment ID")
+    author: str = Field(..., title="Comment author username")
+    body: str = Field(..., title="Comment text")
+    created: str = Field(..., title="Creation timestamp")
+    updated: Optional[str] = Field(None, title="Last update timestamp")
+    
+    model_config = {
+        "title": "Comment",
+        "extra": "ignore",
+    }
+
+
+class Transition(BaseModel):
+    """Information about an available workflow transition."""
+    
+    id: str = Field(..., title="Transition ID")
+    name: str = Field(..., title="Transition name")
+    to_status: str = Field(..., title="Target status name")
+    
+    model_config = {
+        "title": "Transition",
+        "extra": "ignore",
+    }
+
+
+class IssueLink(BaseModel):
+    """Information about a link between JIRA issues."""
+    
+    issue_key: str = Field(..., title="Linked issue key")
+    link_type: str = Field(..., title="Link type name")
+    direction: str = Field(..., title="Link direction", examples=["inward", "outward"])
+    relationship: str = Field(..., title="Relationship description", examples=["blocks", "is blocked by"])
+    
+    model_config = {
+        "title": "IssueLink",
+        "extra": "ignore",
+    }
+
+
+class IssueRelationships(BaseModel):
+    """Complete relationship information for a JIRA issue."""
+    
+    issue_key: str = Field(..., title="Source issue key")
+    parent: Optional[str] = Field(None, title="Parent issue key (for subtasks)")
+    subtasks: List[str] = Field(default_factory=list, title="List of subtask keys")
+    issue_links: List[IssueLink] = Field(default_factory=list, title="Issue links")
+    remote_links_count: int = Field(0, title="Number of remote links")
+    
+    model_config = {
+        "title": "IssueRelationships",
+        "extra": "ignore",
+    }
+
+
+class DescendantTree(BaseModel):
+    """Tree structure of issue descendants."""
+    
+    root_issue: str = Field(..., title="Root issue key")
+    max_depth: int = Field(..., title="Maximum traversal depth")
+    total_issues: int = Field(..., title="Total number of issues found")
+    issues: List[IssueSummary] = Field(..., title="All descendant issues")
+    traversal_order: List[Dict[str, Any]] = Field(..., title="Order issues were discovered")
+    
+    model_config = {
+        "title": "DescendantTree", 
+        "extra": "ignore",
+    }
+
+
+class ParentInfo(BaseModel):
+    """Information about an issue's immediate parent."""
+    
+    issue_key: str = Field(..., title="Child issue key")
+    parent_key: Optional[str] = Field(None, title="Parent issue key (None if no parent)")
+    parent_summary: Optional[str] = Field(None, title="Parent issue summary")
+    parent_type: Optional[str] = Field(None, title="Type of parent relationship")
+    
+    model_config = {
+        "title": "ParentInfo",
+        "extra": "ignore",
+    }
+
+
+class AncestorTree(BaseModel):
+    """Tree structure of issue ancestors."""
+    
+    root_issue: str = Field(..., title="Starting issue key")
+    max_depth: int = Field(..., title="Maximum traversal depth")
+    total_ancestors: int = Field(..., title="Total number of ancestors found")
+    ancestors: List[IssueSummary] = Field(..., title="All ancestor issues")
+    traversal_order: List[Dict[str, Any]] = Field(..., title="Order ancestors were discovered")
+    
+    model_config = {
+        "title": "AncestorTree",
+        "extra": "ignore",
+    }
+
+
 ###############################################################################
 # Tools implementation                                                         #
 ###############################################################################
@@ -164,6 +366,288 @@ class JiraTools:
             "a positive integer (e.g., `7877`).  Example: `RFE-7877`."
         )
 
+    # ------------------------------------------------------------------
+    # Issue relationships
+    # ------------------------------------------------------------------
+    async def get_issue_relationships(self, issue_key: str) -> IssueRelationships:
+        """Get all relationships for a specific JIRA issue."""
+        issue_data = self._client.get_issue(issue_key, expand="issuelinks")
+        fields = issue_data.get("fields", {})
+        
+        # Extract parent (for subtasks)
+        parent = None
+        parent_data = fields.get("parent")
+        if parent_data:
+            parent = parent_data.get("key")
+        
+        # Extract subtasks
+        subtasks = []
+        subtask_data = fields.get("subtasks", [])
+        for subtask in subtask_data:
+            subtask_key = subtask.get("key")
+            if subtask_key:
+                subtasks.append(subtask_key)
+        
+        # Extract issue links
+        issue_links = []
+        links_data = fields.get("issuelinks", [])
+        for link in links_data:
+            link_type = link.get("type", {})
+            link_type_name = link_type.get("name", "unknown")
+            
+            # Handle inward links
+            inward_issue = link.get("inwardIssue")
+            if inward_issue:
+                issue_links.append(IssueLink(
+                    issue_key=inward_issue.get("key"),
+                    link_type=link_type_name,
+                    direction="inward",
+                    relationship=link_type.get("inward", "related")
+                ))
+            
+            # Handle outward links
+            outward_issue = link.get("outwardIssue")
+            if outward_issue:
+                issue_links.append(IssueLink(
+                    issue_key=outward_issue.get("key"),
+                    link_type=link_type_name,
+                    direction="outward",
+                    relationship=link_type.get("outward", "related")
+                ))
+        
+        # Count remote links
+        remote_links = self._client.get_remote_links(issue_key)
+        remote_links_count = len(remote_links)
+        
+        return IssueRelationships(
+            issue_key=issue_key,
+            parent=parent,
+            subtasks=subtasks,
+            issue_links=issue_links,
+            remote_links_count=remote_links_count
+        )
+
+    async def get_descendants(self, issue_key: str, max_depth: int = 3, 
+                             include_subtasks: bool = True, include_links: bool = True,
+                             include_parent_links: bool = False) -> DescendantTree:
+        """Get all descendants of an issue using the existing JiraClient traversal logic."""
+        descendants_data = self._client.get_descendants(
+            issue_key=issue_key,
+            depth=max_depth,
+            include_subtasks=include_subtasks,
+            include_links=include_links,
+            include_remote_links=False,  # We don't need remote links for descendants
+            include_parent_links=include_parent_links
+        )
+        
+        # Extract metadata
+        metadata = descendants_data.pop("_extraction_metadata", {})
+        traversal_order = metadata.get("traversal_order", [])
+        
+        # Convert issue data to IssueSummary objects
+        issues = []
+        for key, issue_data in descendants_data.items():
+            if key == issue_key:  # Skip the root issue itself
+                continue
+                
+            fields = issue_data.get("fields", {})
+            issues.append(IssueSummary(
+                key=key,
+                summary=fields.get("summary", ""),
+                status=fields.get("status", {}).get("name", ""),
+                url=f"{self._client.base_url}/browse/{key}"
+            ))
+        
+        return DescendantTree(
+            root_issue=issue_key,
+            max_depth=max_depth,
+            total_issues=len(issues),
+            issues=issues,
+            traversal_order=traversal_order
+        )
+
+    async def get_children(self, issue_key: str, include_parent_links: bool = False,
+                          parent_link_field: str = "Parent Link") -> List[IssueSummary]:
+        """Get direct children of an issue (subtasks and optionally parent-link children)."""
+        children = []
+        
+        # Get the issue to extract subtasks
+        issue_data = self._client.get_issue(issue_key)
+        fields = issue_data.get("fields", {})
+        
+        # Add subtasks
+        subtasks = fields.get("subtasks", [])
+        for subtask in subtasks:
+            subtask_key = subtask.get("key")
+            if subtask_key:
+                subtask_fields = subtask.get("fields", {})
+                children.append(IssueSummary(
+                    key=subtask_key,
+                    summary=subtask_fields.get("summary", ""),
+                    status=subtask_fields.get("status", {}).get("name", ""),
+                    url=f"{self._client.base_url}/browse/{subtask_key}"
+                ))
+        
+        # Add parent-link children if requested
+        if include_parent_links:
+            parent_link_children = self._client.get_parent_link_children(issue_key, parent_link_field)
+            for child_key in parent_link_children:
+                # Fetch details for each child
+                try:
+                    child_data = self._client.get_issue(child_key)
+                    child_fields = child_data.get("fields", {})
+                    children.append(IssueSummary(
+                        key=child_key,
+                        summary=child_fields.get("summary", ""),
+                        status=child_fields.get("status", {}).get("name", ""),
+                        url=f"{self._client.base_url}/browse/{child_key}"
+                    ))
+                except Exception as e:
+                    self._logger.warning(f"Could not fetch details for parent-link child {child_key}: {e}")
+                    continue
+        
+        return children
+
+    async def get_linked_issues(self, issue_key: str, link_type: Optional[str] = None) -> List[IssueLink]:
+        """Get issues linked to the specified issue via JIRA issue links."""
+        issue_data = self._client.get_issue(issue_key, expand="issuelinks")
+        fields = issue_data.get("fields", {})
+        
+        issue_links = []
+        links_data = fields.get("issuelinks", [])
+        
+        for link in links_data:
+            link_type_data = link.get("type", {})
+            link_type_name = link_type_data.get("name", "unknown")
+            
+            # Skip if filtering by link type and this doesn't match
+            if link_type and link_type_name.lower() != link_type.lower():
+                continue
+            
+            # Handle inward links
+            inward_issue = link.get("inwardIssue")
+            if inward_issue:
+                issue_links.append(IssueLink(
+                    issue_key=inward_issue.get("key"),
+                    link_type=link_type_name,
+                    direction="inward",
+                    relationship=link_type_data.get("inward", "related")
+                ))
+            
+            # Handle outward links
+            outward_issue = link.get("outwardIssue")
+            if outward_issue:
+                issue_links.append(IssueLink(
+                    issue_key=outward_issue.get("key"),
+                    link_type=link_type_name,
+                    direction="outward",
+                    relationship=link_type_data.get("outward", "related")
+                ))
+        
+        return issue_links
+
+    async def get_parent(self, issue_key: str, include_parent_links: bool = True,
+                        parent_link_field: str = "Parent Link") -> ParentInfo:
+        """Get the immediate parent of an issue."""
+        issue_data = self._client.get_issue(issue_key, expand="parent")
+        fields = issue_data.get("fields", {})
+        
+        parent_key = None
+        parent_summary = None
+        parent_type = None
+        
+        # Check for subtask parent first
+        parent = fields.get("parent")
+        if parent:
+            parent_key = parent.get("key")
+            parent_summary = parent.get("fields", {}).get("summary", "")
+            parent_type = "subtask"
+        
+        # Check for custom parent link field if no subtask parent found and enabled
+        elif include_parent_links:
+            field_metadata = self._client.get_field_by_name(parent_link_field)
+            if field_metadata:
+                field_id = field_metadata.get("id")
+                if field_id:
+                    parent_link = fields.get(field_id)
+                    if parent_link:
+                        parent_key = parent_link
+                        parent_type = f"parent_link({parent_link_field})"
+                        
+                        # Fetch parent summary
+                        try:
+                            parent_data = self._client.get_issue(parent_key)
+                            parent_summary = parent_data.get("fields", {}).get("summary", "")
+                        except Exception as e:
+                            self._logger.warning(f"Could not fetch parent {parent_key} details: {e}")
+        
+        return ParentInfo(
+            issue_key=issue_key,
+            parent_key=parent_key,
+            parent_summary=parent_summary,
+            parent_type=parent_type
+        )
+
+    async def get_ancestors(self, issue_key: str, max_depth: int = 5,
+                           include_parent_links: bool = True,
+                           parent_link_field: str = "Parent Link") -> AncestorTree:
+        """Get all ancestors of an issue by following parent relationships recursively."""
+        ancestors = []
+        traversal_order = []
+        visited = set()
+        current_key = issue_key
+        current_depth = 0
+        
+        while current_key and current_key not in visited and (max_depth == -1 or current_depth < max_depth):
+            visited.add(current_key)
+            
+            # Get parent of current issue
+            parent_info = await self.get_parent(current_key, include_parent_links, parent_link_field)
+            
+            if parent_info.parent_key:
+                # Check if parent is already visited (cycle detection)
+                if parent_info.parent_key in visited:
+                    self._logger.debug(f"Cycle detected: {parent_info.parent_key} already visited")
+                    break
+                
+                # Fetch full parent details
+                try:
+                    parent_data = self._client.get_issue(parent_info.parent_key)
+                    parent_fields = parent_data.get("fields", {})
+                    
+                    ancestor_summary = IssueSummary(
+                        key=parent_info.parent_key,
+                        summary=parent_fields.get("summary", ""),
+                        status=parent_fields.get("status", {}).get("name", ""),
+                        url=f"{self._client.base_url}/browse/{parent_info.parent_key}"
+                    )
+                    
+                    ancestors.append(ancestor_summary)
+                    traversal_order.append({
+                        "issue_key": parent_info.parent_key,
+                        "depth": current_depth,
+                        "parent_type": parent_info.parent_type
+                    })
+                    
+                    # Move to parent for next iteration
+                    current_key = parent_info.parent_key
+                    current_depth += 1
+                    
+                except Exception as e:
+                    self._logger.warning(f"Could not fetch ancestor {parent_info.parent_key}: {e}")
+                    break
+            else:
+                # No parent found, stop traversal
+                break
+        
+        return AncestorTree(
+            root_issue=issue_key,
+            max_depth=max_depth,
+            total_ancestors=len(ancestors),
+            ancestors=ancestors,
+            traversal_order=traversal_order
+        )
+
 
 ###############################################################################
 # Server factory                                                               #
@@ -192,8 +676,19 @@ def create_server(
     mcp = FastMCP(
         name="JIRA Read-Only MCP Server",
         instructions=(
-            "You are a helpful assistant that provides access to read-only JIRA information. "
-            "Use the search and get_issue tools to help users retrieve issue data."
+            "You are a JIRA expert assistant with comprehensive read-only access to JIRA data. "
+            "WORKFLOW GUIDANCE: "
+            "1. START with search_issues() to find relevant issues by project, status, or content "
+            "2. Use get_issue() for detailed information about specific issues "
+            "3. EXPLORE RELATIONSHIPS with: "
+            "   - get_issue_relationships() for relationship overview "
+            "   - get_descendants() for impact analysis (what depends on this?) "
+            "   - get_ancestors() for context (what is this part of?) "
+            "   - get_children() for immediate children only "
+            "   - get_parent() for immediate parent only "
+            "   - get_linked_issues() for horizontal relationships (blocks, depends) "
+            "4. Use identifier_hint() when users provide invalid issue keys "
+            "CHOOSE TOOLS WISELY: Use specific relationship tools based on user needs rather than always using the broadest option."
         ),
     )
 
@@ -206,8 +701,11 @@ def create_server(
     @mcp.tool(
         name="search_issues",
         description=(
-            "Search JIRA for issues. Accepts either full JQL or a simple search term. "
-            "Returns a list of matching issues with key, summary, status, and URL."
+            "Search JIRA for issues using JQL queries or simple text. Use this as your starting point "
+            "to find issues by project, status, assignee, text content, or any JIRA field. "
+            "Automatically detects JQL (if contains =, AND, OR) vs simple text search. "
+            "Returns basic issue info - use get_issue() for full details of specific issues. "
+            "Example: 'project = PROJ AND status = Open' or 'authentication bug'"
         ),
         annotations=ToolAnnotations(
             readOnlyHint=True,
@@ -221,7 +719,12 @@ def create_server(
 
     @mcp.tool(
         name="get_issue",
-        description="Retrieve detailed information for a single JIRA issue.",
+        description=(
+            "Get comprehensive details for a specific JIRA issue including description, fields, "
+            "status, assignee, and full raw data. Use this after search_issues() to get complete "
+            "information about specific issues you've identified. The 'expand' parameter can "
+            "include additional data like 'changelog,comments,attachments'."
+        ),
         annotations=ToolAnnotations(
             readOnlyHint=True,
             destructiveHint=False,
@@ -234,7 +737,11 @@ def create_server(
 
     @mcp.tool(
         name="identifier_hint",
-        description="Return a short text explaining the PROJECT-NUMBER pattern (e.g., RFE-7877).",
+        description=(
+            "Get help with JIRA issue key format (PROJECT-NUMBER pattern like PROJ-123). "
+            "Use this when users provide invalid issue keys or need guidance on the expected format. "
+            "Useful for explaining JIRA issue identifier structure to users."
+        ),
         annotations=ToolAnnotations(
             readOnlyHint=True,
             destructiveHint=False,
@@ -244,6 +751,137 @@ def create_server(
     )
     async def identifier_hint_tool() -> str:
         return await tools.identifier_hint()
+
+    @mcp.tool(
+        name="get_issue_relationships",
+        description=(
+            "Get a comprehensive overview of all relationships for an issue: parent, subtasks, "
+            "issue links (blocks/depends), and remote links. Use this for a quick relationship "
+            "summary before diving deeper with get_children(), get_parent(), or get_descendants(). "
+            "Ideal for understanding an issue's context within the project hierarchy."
+        ),
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+    )
+    async def get_issue_relationships_tool(issue_key: str) -> IssueRelationships:
+        return await tools.get_issue_relationships(issue_key)
+
+    @mcp.tool(
+        name="get_descendants",
+        description=(
+            "Traverse DOWN the issue hierarchy to find all child issues, grandchildren, etc. "
+            "Follows subtask relationships and issue links (blocks/depends) to build a complete "
+            "descendant tree. Use for impact analysis: 'What work depends on this issue?' "
+            "Default depth=3 levels for performance. Use max_depth=-1 for unlimited traversal "
+            "(caution: can be slow on large hierarchies). Complements get_ancestors()."
+        ),
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+    )
+    async def get_descendants_tool(
+        issue_key: str, 
+        max_depth: int = 3,
+        include_subtasks: bool = True,
+        include_links: bool = True,
+        include_parent_links: bool = False
+    ) -> DescendantTree:
+        return await tools.get_descendants(
+            issue_key, max_depth, include_subtasks, include_links, include_parent_links
+        )
+
+    @mcp.tool(
+        name="get_children",
+        description=(
+            "Get immediate children only (1 level down) - subtasks and optionally custom "
+            "parent-link field children. Use this instead of get_descendants() when you only "
+            "need direct children, not the full hierarchy. Faster and more focused than "
+            "get_descendants() with max_depth=1. Commonly used for Epic→Story or Story→Task relationships."
+        ),
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+    )
+    async def get_children_tool(
+        issue_key: str,
+        include_parent_links: bool = False,
+        parent_link_field: str = "Parent Link"
+    ) -> List[IssueSummary]:
+        return await tools.get_children(issue_key, include_parent_links, parent_link_field)
+
+    @mcp.tool(
+        name="get_linked_issues",
+        description=(
+            "Get horizontally linked issues (blocks, depends on, relates to, etc.) without "
+            "hierarchy traversal. Use for finding related work at the same level, dependencies, "
+            "or blocking relationships. Filter by link_type (e.g., 'blocks', 'depends') to focus "
+            "on specific relationship types. Different from parent/child relationships."
+        ),
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+    )
+    async def get_linked_issues_tool(issue_key: str, link_type: Optional[str] = None) -> List[IssueLink]:
+        return await tools.get_linked_issues(issue_key, link_type)
+
+    @mcp.tool(
+        name="get_parent",
+        description=(
+            "Get the immediate parent issue (1 level up) through subtask or custom parent-link "
+            "relationships. Use to find what Epic contains this Story, or what Story contains "
+            "this Task. Returns None if no parent exists. For full parent chain, use get_ancestors(). "
+            "Handles both standard JIRA subtasks and custom Epic Link fields."
+        ),
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+    )
+    async def get_parent_tool(
+        issue_key: str,
+        include_parent_links: bool = True,
+        parent_link_field: str = "Parent Link"
+    ) -> ParentInfo:
+        return await tools.get_parent(issue_key, include_parent_links, parent_link_field)
+
+    @mcp.tool(
+        name="get_ancestors",
+        description=(
+            "Traverse UP the issue hierarchy to find all parent issues, grandparents, etc. "
+            "Follows parent relationships to the root of the hierarchy. Use for understanding "
+            "the full context: 'What Epic/Initiative does this task belong to?' "
+            "Default depth=5 levels (ancestors are usually linear chains). Use max_depth=-1 "
+            "for unlimited traversal. Complements get_descendants() for full hierarchy view."
+        ),
+        annotations=ToolAnnotations(
+            readOnlyHint=True,
+            destructiveHint=False,
+            idempotentHint=True,
+            openWorldHint=False,
+        ),
+    )
+    async def get_ancestors_tool(
+        issue_key: str,
+        max_depth: int = 5,
+        include_parent_links: bool = True,
+        parent_link_field: str = "Parent Link"
+    ) -> AncestorTree:
+        return await tools.get_ancestors(issue_key, max_depth, include_parent_links, parent_link_field)
 
     return mcp
 

--- a/mcp_jira_server/test_server.py
+++ b/mcp_jira_server/test_server.py
@@ -93,23 +93,27 @@ class TestServer(unittest.TestCase):
         mock_fastmcp.assert_called_once()
         call_args = mock_fastmcp.call_args
         self.assertEqual(call_args[1]["name"], "JIRA Read-Only MCP Server")
-        self.assertIn("helpful assistant", call_args[1]["instructions"])
+        self.assertIn("JIRA expert assistant", call_args[1]["instructions"])
 
     @patch("mcp_jira_server.server.JiraClient")
     @patch("mcp_jira_server.server.FastMCP")
-    def test_server_06_server_registers_all_three_tools(self, mock_fastmcp, mock_client):
-        """SERVER-06: Server registers all three tools."""
+    def test_server_06_server_registers_all_nine_tools(self, mock_fastmcp, mock_client):
+        """SERVER-06: Server registers all nine tools."""
         mock_server = Mock()
         mock_fastmcp.return_value = mock_server
         
         create_server(url="https://test.jira.com")
         
-        # Check that tool decorator was called 3 times
-        self.assertEqual(mock_server.tool.call_count, 3)
+        # Check that tool decorator was called 9 times
+        self.assertEqual(mock_server.tool.call_count, 9)
         
         # Check tool names
         tool_names = [call[1]["name"] for call in mock_server.tool.call_args_list]
-        expected_names = ["search_issues", "get_issue", "identifier_hint"]
+        expected_names = [
+            "search_issues", "get_issue", "identifier_hint",
+            "get_issue_relationships", "get_descendants", "get_children", "get_linked_issues",
+            "get_parent", "get_ancestors"
+        ]
         for name in expected_names:
             self.assertIn(name, tool_names)
 

--- a/mcp_jira_server/test_tools.py
+++ b/mcp_jira_server/test_tools.py
@@ -10,7 +10,10 @@ from unittest.mock import Mock
 import asyncio
 
 # Import modules under test  
-from mcp_jira_server.server import JiraTools, IssueSummary, IssueDetails
+from mcp_jira_server.server import (
+    JiraTools, IssueSummary, IssueDetails, IssueRelationships, 
+    IssueLink, DescendantTree, ParentInfo, AncestorTree
+)
 
 
 class TestTools(unittest.TestCase):
@@ -167,6 +170,541 @@ class TestTools(unittest.TestCase):
         
         self.assertIn("PROJECT>-<NUMBER>", result)
         self.assertIn("RFE-7877", result)
+
+    def test_tools_12_get_issue_relationships_with_all_types(self):
+        """TOOLS-12: Get issue relationships with all relationship types."""
+        self.mock_client.get_issue.return_value = {
+            "key": "TEST-100",
+            "fields": {
+                "parent": {"key": "TEST-99"},
+                "subtasks": [
+                    {"key": "TEST-101", "fields": {"summary": "Subtask 1", "status": {"name": "Open"}}},
+                    {"key": "TEST-102", "fields": {"summary": "Subtask 2", "status": {"name": "Done"}}}
+                ],
+                "issuelinks": [
+                    {
+                        "type": {"name": "Blocks", "inward": "is blocked by", "outward": "blocks"},
+                        "inwardIssue": {"key": "TEST-50"}
+                    },
+                    {
+                        "type": {"name": "Depends", "inward": "depends on", "outward": "is depended on by"},
+                        "outwardIssue": {"key": "TEST-200"}
+                    }
+                ]
+            }
+        }
+        self.mock_client.get_remote_links.return_value = [{"id": "1"}, {"id": "2"}]
+        
+        result = asyncio.run(self.tools.get_issue_relationships("TEST-100"))
+        
+        self.assertIsInstance(result, IssueRelationships)
+        self.assertEqual(result.issue_key, "TEST-100")
+        self.assertEqual(result.parent, "TEST-99")
+        self.assertEqual(len(result.subtasks), 2)
+        self.assertIn("TEST-101", result.subtasks)
+        self.assertIn("TEST-102", result.subtasks)
+        self.assertEqual(len(result.issue_links), 2)
+        self.assertEqual(result.remote_links_count, 2)
+
+    def test_tools_13_get_issue_relationships_with_no_relationships(self):
+        """TOOLS-13: Get issue relationships with no relationships."""
+        self.mock_client.get_issue.return_value = {
+            "key": "TEST-SOLO",
+            "fields": {
+                "subtasks": [],
+                "issuelinks": []
+            }
+        }
+        self.mock_client.get_remote_links.return_value = []
+        
+        result = asyncio.run(self.tools.get_issue_relationships("TEST-SOLO"))
+        
+        self.assertEqual(result.parent, None)
+        self.assertEqual(len(result.subtasks), 0)
+        self.assertEqual(len(result.issue_links), 0)
+        self.assertEqual(result.remote_links_count, 0)
+
+    def test_tools_14_get_issue_relationships_link_parsing(self):
+        """TOOLS-14: Get issue relationships link parsing."""
+        self.mock_client.get_issue.return_value = {
+            "key": "TEST-LINK",
+            "fields": {
+                "subtasks": [],
+                "issuelinks": [
+                    {
+                        "type": {"name": "Blocks", "inward": "is blocked by", "outward": "blocks"},
+                        "inwardIssue": {"key": "TEST-IN"}
+                    },
+                    {
+                        "type": {"name": "Relates", "inward": "relates to", "outward": "relates to"},
+                        "outwardIssue": {"key": "TEST-OUT"}
+                    }
+                ]
+            }
+        }
+        self.mock_client.get_remote_links.return_value = []
+        
+        result = asyncio.run(self.tools.get_issue_relationships("TEST-LINK"))
+        
+        # Check inward link
+        inward_link = next(link for link in result.issue_links if link.direction == "inward")
+        self.assertIsInstance(inward_link, IssueLink)
+        self.assertEqual(inward_link.issue_key, "TEST-IN")
+        self.assertEqual(inward_link.link_type, "Blocks")
+        self.assertEqual(inward_link.relationship, "is blocked by")
+        
+        # Check outward link
+        outward_link = next(link for link in result.issue_links if link.direction == "outward")
+        self.assertEqual(outward_link.issue_key, "TEST-OUT")
+        self.assertEqual(outward_link.link_type, "Relates")
+        self.assertEqual(outward_link.relationship, "relates to")
+
+    def test_tools_15_get_descendants_basic_functionality(self):
+        """TOOLS-15: Get descendants basic functionality."""
+        self.mock_client.get_descendants.return_value = {
+            "TEST-CHILD1": {
+                "key": "TEST-CHILD1",
+                "fields": {"summary": "Child 1", "status": {"name": "Open"}}
+            },
+            "TEST-CHILD2": {
+                "key": "TEST-CHILD2", 
+                "fields": {"summary": "Child 2", "status": {"name": "Done"}}
+            },
+            "_extraction_metadata": {
+                "traversal_order": [
+                    {"issue_key": "TEST-PARENT", "depth": 0},
+                    {"issue_key": "TEST-CHILD1", "depth": 1},
+                    {"issue_key": "TEST-CHILD2", "depth": 1}
+                ]
+            }
+        }
+        
+        result = asyncio.run(self.tools.get_descendants("TEST-PARENT", max_depth=2))
+        
+        self.assertIsInstance(result, DescendantTree)
+        self.assertEqual(result.root_issue, "TEST-PARENT")
+        self.assertEqual(result.max_depth, 2)
+        self.assertEqual(result.total_issues, 2)
+        self.assertEqual(len(result.issues), 2)
+        self.assertEqual(len(result.traversal_order), 3)
+
+    def test_tools_16_get_descendants_excludes_root_issue(self):
+        """TOOLS-16: Get descendants excludes root issue from results."""
+        self.mock_client.get_descendants.return_value = {
+            "TEST-ROOT": {
+                "key": "TEST-ROOT",
+                "fields": {"summary": "Root", "status": {"name": "Open"}}
+            },
+            "TEST-CHILD": {
+                "key": "TEST-CHILD",
+                "fields": {"summary": "Child", "status": {"name": "Open"}}
+            },
+            "_extraction_metadata": {"traversal_order": []}
+        }
+        
+        result = asyncio.run(self.tools.get_descendants("TEST-ROOT"))
+        
+        # Root issue should not be in the issues list
+        self.assertEqual(len(result.issues), 1)
+        self.assertEqual(result.issues[0].key, "TEST-CHILD")
+
+    def test_tools_17_get_descendants_with_parameters(self):
+        """TOOLS-17: Get descendants with custom parameters."""
+        self.mock_client.get_descendants.return_value = {
+            "_extraction_metadata": {"traversal_order": []}
+        }
+        
+        asyncio.run(self.tools.get_descendants(
+            "TEST-PARAM",
+            max_depth=5,
+            include_subtasks=False,
+            include_links=True,
+            include_parent_links=True
+        ))
+        
+        self.mock_client.get_descendants.assert_called_once_with(
+            issue_key="TEST-PARAM",
+            depth=5,
+            include_subtasks=False,
+            include_links=True,
+            include_remote_links=False,  # Always False for descendants
+            include_parent_links=True
+        )
+
+    def test_tools_18_get_children_with_subtasks_only(self):
+        """TOOLS-18: Get children with subtasks only."""
+        self.mock_client.get_issue.return_value = {
+            "key": "TEST-PARENT",
+            "fields": {
+                "subtasks": [
+                    {
+                        "key": "TEST-SUB1",
+                        "fields": {"summary": "Subtask 1", "status": {"name": "Open"}}
+                    },
+                    {
+                        "key": "TEST-SUB2", 
+                        "fields": {"summary": "Subtask 2", "status": {"name": "Done"}}
+                    }
+                ]
+            }
+        }
+        
+        result = asyncio.run(self.tools.get_children("TEST-PARENT"))
+        
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].key, "TEST-SUB1")
+        self.assertEqual(result[1].key, "TEST-SUB2")
+        self.assertIsInstance(result[0], IssueSummary)
+
+    def test_tools_19_get_children_with_parent_links(self):
+        """TOOLS-19: Get children with parent links enabled."""
+        self.mock_client.get_issue.side_effect = [
+            # First call for getting subtasks
+            {"key": "TEST-PARENT", "fields": {"subtasks": []}},
+            # Subsequent calls for parent-link children
+            {"key": "TEST-PCHILD1", "fields": {"summary": "Parent Child 1", "status": {"name": "Open"}}},
+            {"key": "TEST-PCHILD2", "fields": {"summary": "Parent Child 2", "status": {"name": "In Progress"}}}
+        ]
+        self.mock_client.get_parent_link_children.return_value = ["TEST-PCHILD1", "TEST-PCHILD2"]
+        
+        result = asyncio.run(self.tools.get_children(
+            "TEST-PARENT", 
+            include_parent_links=True,
+            parent_link_field="Custom Parent"
+        ))
+        
+        self.mock_client.get_parent_link_children.assert_called_once_with("TEST-PARENT", "Custom Parent")
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].key, "TEST-PCHILD1")
+        self.assertEqual(result[1].key, "TEST-PCHILD2")
+
+    def test_tools_20_get_children_handles_parent_link_errors(self):
+        """TOOLS-20: Get children handles parent link fetch errors gracefully."""
+        self.mock_client.get_issue.side_effect = [
+            {"key": "TEST-PARENT", "fields": {"subtasks": []}},
+            Exception("Network error")  # Second call fails
+        ]
+        self.mock_client.get_parent_link_children.return_value = ["TEST-FAIL"]
+        
+        result = asyncio.run(self.tools.get_children("TEST-PARENT", include_parent_links=True))
+        
+        # Should return empty list since subtasks were empty and parent-link child failed
+        self.assertEqual(len(result), 0)
+
+    def test_tools_21_get_linked_issues_all_links(self):
+        """TOOLS-21: Get linked issues returns all links."""
+        self.mock_client.get_issue.return_value = {
+            "key": "TEST-CENTRAL",
+            "fields": {
+                "issuelinks": [
+                    {
+                        "type": {"name": "Blocks", "inward": "is blocked by", "outward": "blocks"},
+                        "inwardIssue": {"key": "TEST-BLOCKER"}
+                    },
+                    {
+                        "type": {"name": "Relates", "inward": "relates to", "outward": "relates to"},
+                        "outwardIssue": {"key": "TEST-RELATED"}
+                    },
+                    {
+                        "type": {"name": "Duplicates", "inward": "is duplicated by", "outward": "duplicates"},
+                        "outwardIssue": {"key": "TEST-DUP"}
+                    }
+                ]
+            }
+        }
+        
+        result = asyncio.run(self.tools.get_linked_issues("TEST-CENTRAL"))
+        
+        self.assertEqual(len(result), 3)
+        link_keys = [link.issue_key for link in result]
+        self.assertIn("TEST-BLOCKER", link_keys)
+        self.assertIn("TEST-RELATED", link_keys)
+        self.assertIn("TEST-DUP", link_keys)
+
+    def test_tools_22_get_linked_issues_with_filter(self):
+        """TOOLS-22: Get linked issues with link type filter."""
+        self.mock_client.get_issue.return_value = {
+            "key": "TEST-FILTER",
+            "fields": {
+                "issuelinks": [
+                    {
+                        "type": {"name": "Blocks", "inward": "is blocked by", "outward": "blocks"},
+                        "inwardIssue": {"key": "TEST-BLOCKER"}
+                    },
+                    {
+                        "type": {"name": "Relates", "inward": "relates to", "outward": "relates to"},
+                        "outwardIssue": {"key": "TEST-RELATED"}
+                    }
+                ]
+            }
+        }
+        
+        result = asyncio.run(self.tools.get_linked_issues("TEST-FILTER", link_type="Blocks"))
+        
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].issue_key, "TEST-BLOCKER")
+        self.assertEqual(result[0].link_type, "Blocks")
+
+    def test_tools_23_get_linked_issues_case_insensitive_filter(self):
+        """TOOLS-23: Get linked issues with case-insensitive filter."""
+        self.mock_client.get_issue.return_value = {
+            "key": "TEST-CASE",
+            "fields": {
+                "issuelinks": [
+                    {
+                        "type": {"name": "Blocks", "inward": "is blocked by", "outward": "blocks"},
+                        "inwardIssue": {"key": "TEST-MATCH"}
+                    }
+                ]
+            }
+        }
+        
+        result = asyncio.run(self.tools.get_linked_issues("TEST-CASE", link_type="blocks"))
+        
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].issue_key, "TEST-MATCH")
+
+    def test_tools_24_get_linked_issues_no_matches(self):
+        """TOOLS-24: Get linked issues with no matching links."""
+        self.mock_client.get_issue.return_value = {
+            "key": "TEST-NOMATCH",
+            "fields": {
+                "issuelinks": [
+                    {
+                        "type": {"name": "Blocks", "inward": "is blocked by", "outward": "blocks"},
+                        "inwardIssue": {"key": "TEST-OTHER"}
+                    }
+                ]
+            }
+        }
+        
+        result = asyncio.run(self.tools.get_linked_issues("TEST-NOMATCH", link_type="NonExistent"))
+        
+        self.assertEqual(len(result), 0)
+
+    def test_tools_25_get_linked_issues_handles_missing_link_data(self):
+        """TOOLS-25: Get linked issues handles missing or malformed link data."""
+        self.mock_client.get_issue.return_value = {
+            "key": "TEST-MALFORMED",
+            "fields": {
+                "issuelinks": [
+                    {
+                        "type": {"name": "Blocks"},  # Missing inward/outward
+                        "inwardIssue": {"key": "TEST-VALID"}
+                    },
+                    {
+                        "type": {},  # Missing name
+                        "outwardIssue": {"key": "TEST-NONAME"}
+                    },
+                    {}  # Completely empty link
+                ]
+            }
+        }
+        
+        result = asyncio.run(self.tools.get_linked_issues("TEST-MALFORMED"))
+        
+        # Should handle malformed data gracefully
+        self.assertEqual(len(result), 2)  # Only the valid ones
+        self.assertEqual(result[0].link_type, "Blocks")
+        self.assertEqual(result[1].link_type, "unknown")  # Fallback for missing name
+
+    def test_tools_26_get_parent_with_subtask_parent(self):
+        """TOOLS-26: Get parent with subtask parent relationship."""
+        self.mock_client.get_issue.return_value = {
+            "fields": {
+                "parent": {
+                    "key": "TEST-PARENT",
+                    "fields": {
+                        "summary": "Parent Issue Summary"
+                    }
+                }
+            }
+        }
+        
+        result = asyncio.run(self.tools.get_parent("TEST-CHILD"))
+        
+        self.assertIsInstance(result, ParentInfo)
+        self.assertEqual(result.issue_key, "TEST-CHILD")
+        self.assertEqual(result.parent_key, "TEST-PARENT")
+        self.assertEqual(result.parent_summary, "Parent Issue Summary")
+        self.assertEqual(result.parent_type, "subtask")
+
+    def test_tools_27_get_parent_with_no_parent(self):
+        """TOOLS-27: Get parent with no parent relationship."""
+        self.mock_client.get_issue.return_value = {"fields": {}}
+        self.mock_client.get_field_by_name.return_value = None
+        
+        result = asyncio.run(self.tools.get_parent("TEST-ORPHAN"))
+        
+        self.assertIsInstance(result, ParentInfo)
+        self.assertEqual(result.issue_key, "TEST-ORPHAN")
+        self.assertIsNone(result.parent_key)
+        self.assertIsNone(result.parent_summary)
+        self.assertIsNone(result.parent_type)
+
+    def test_tools_28_get_parent_with_parent_link_field(self):
+        """TOOLS-28: Get parent with custom parent link field."""
+        self.mock_client.get_issue.return_value = {"fields": {}}  # Child issue with no subtask parent and no parent link value
+        self.mock_client.get_field_by_name.return_value = {"id": "customfield_12345"}
+        
+        result = asyncio.run(self.tools.get_parent("TEST-CHILD", parent_link_field="Epic Link"))
+        
+        # Should call get_issue once: only for the child (no parent link value means no second call)
+        self.assertEqual(self.mock_client.get_issue.call_count, 1)
+        
+        self.assertEqual(result.issue_key, "TEST-CHILD")
+        self.assertIsNone(result.parent_key)  # No parent link value in fields
+
+    def test_tools_29_get_parent_with_parent_link_value(self):
+        """TOOLS-29: Get parent with parent link field containing value."""
+        self.mock_client.get_issue.side_effect = [
+            {"fields": {"customfield_12345": "TEST-EPIC"}},  # Child with parent link
+            {"fields": {"summary": "Epic Summary"}}  # Parent issue
+        ]
+        self.mock_client.get_field_by_name.return_value = {"id": "customfield_12345"}
+        
+        result = asyncio.run(self.tools.get_parent("TEST-CHILD", parent_link_field="Epic Link"))
+        
+        self.assertEqual(result.issue_key, "TEST-CHILD")
+        self.assertEqual(result.parent_key, "TEST-EPIC")
+        self.assertEqual(result.parent_summary, "Epic Summary")
+        self.assertEqual(result.parent_type, "parent_link(Epic Link)")
+
+    def test_tools_30_get_ancestors_single_level(self):
+        """TOOLS-30: Get ancestors with single level hierarchy."""
+        # Mock get_parent calls
+        async def mock_get_parent(issue_key, include_parent_links=True, parent_link_field="Parent Link"):
+            if issue_key == "TEST-CHILD":
+                return ParentInfo(
+                    issue_key="TEST-CHILD",
+                    parent_key="TEST-PARENT", 
+                    parent_summary="Parent Summary",
+                    parent_type="subtask"
+                )
+            else:
+                return ParentInfo(
+                    issue_key="TEST-PARENT",
+                    parent_key=None,
+                    parent_summary=None,
+                    parent_type=None
+                )
+        
+        self.tools.get_parent = mock_get_parent
+        self.mock_client.get_issue.return_value = {
+            "fields": {
+                "summary": "Parent Summary",
+                "status": {"name": "Open"}
+            }
+        }
+        
+        result = asyncio.run(self.tools.get_ancestors("TEST-CHILD"))
+        
+        self.assertIsInstance(result, AncestorTree)
+        self.assertEqual(result.root_issue, "TEST-CHILD")
+        self.assertEqual(result.total_ancestors, 1)
+        self.assertEqual(len(result.ancestors), 1)
+        self.assertEqual(result.ancestors[0].key, "TEST-PARENT")
+        self.assertEqual(len(result.traversal_order), 1)
+
+    def test_tools_31_get_ancestors_multi_level(self):
+        """TOOLS-31: Get ancestors with multi-level hierarchy."""
+        # Mock get_parent calls for 3-level hierarchy
+        async def mock_get_parent(issue_key, include_parent_links=True, parent_link_field="Parent Link"):
+            parent_map = {
+                "TEST-CHILD": ParentInfo(issue_key="TEST-CHILD", parent_key="TEST-PARENT", parent_summary="Parent Summary", parent_type="subtask"),
+                "TEST-PARENT": ParentInfo(issue_key="TEST-PARENT", parent_key="TEST-GRANDPARENT", parent_summary="Grandparent Summary", parent_type="subtask"),
+                "TEST-GRANDPARENT": ParentInfo(issue_key="TEST-GRANDPARENT", parent_key=None, parent_summary=None, parent_type=None)
+            }
+            return parent_map.get(issue_key, ParentInfo(issue_key=issue_key, parent_key=None, parent_summary=None, parent_type=None))
+        
+        self.tools.get_parent = mock_get_parent
+        self.mock_client.get_issue.side_effect = [
+            {"fields": {"summary": "Parent Summary", "status": {"name": "Open"}}},
+            {"fields": {"summary": "Grandparent Summary", "status": {"name": "In Progress"}}}
+        ]
+        
+        result = asyncio.run(self.tools.get_ancestors("TEST-CHILD"))
+        
+        self.assertEqual(result.total_ancestors, 2)
+        self.assertEqual(len(result.ancestors), 2)
+        self.assertEqual(result.ancestors[0].key, "TEST-PARENT")
+        self.assertEqual(result.ancestors[1].key, "TEST-GRANDPARENT")
+        self.assertEqual(len(result.traversal_order), 2)
+
+    def test_tools_32_get_ancestors_with_depth_limit(self):
+        """TOOLS-32: Get ancestors with depth limit."""
+        # Mock get_parent calls for 3-level hierarchy
+        async def mock_get_parent(issue_key, include_parent_links=True, parent_link_field="Parent Link"):
+            parent_map = {
+                "TEST-CHILD": ParentInfo(issue_key="TEST-CHILD", parent_key="TEST-PARENT", parent_summary="Parent Summary", parent_type="subtask"),
+                "TEST-PARENT": ParentInfo(issue_key="TEST-PARENT", parent_key="TEST-GRANDPARENT", parent_summary="Grandparent Summary", parent_type="subtask"),
+                "TEST-GRANDPARENT": ParentInfo(issue_key="TEST-GRANDPARENT", parent_key=None, parent_summary=None, parent_type=None)
+            }
+            return parent_map.get(issue_key, ParentInfo(issue_key=issue_key, parent_key=None, parent_summary=None, parent_type=None))
+        
+        self.tools.get_parent = mock_get_parent
+        self.mock_client.get_issue.return_value = {
+            "fields": {"summary": "Parent Summary", "status": {"name": "Open"}}
+        }
+        
+        # Limit to depth 1
+        result = asyncio.run(self.tools.get_ancestors("TEST-CHILD", max_depth=1))
+        
+        self.assertEqual(result.max_depth, 1)
+        self.assertEqual(result.total_ancestors, 1)
+        self.assertEqual(result.ancestors[0].key, "TEST-PARENT")
+
+    def test_tools_33_get_ancestors_no_ancestors(self):
+        """TOOLS-33: Get ancestors for issue with no parents."""
+        async def mock_get_parent(issue_key, include_parent_links=True, parent_link_field="Parent Link"):
+            return ParentInfo(issue_key=issue_key, parent_key=None, parent_summary=None, parent_type=None)
+        
+        self.tools.get_parent = mock_get_parent
+        
+        result = asyncio.run(self.tools.get_ancestors("TEST-ORPHAN"))
+        
+        self.assertEqual(result.total_ancestors, 0)
+        self.assertEqual(len(result.ancestors), 0)
+        self.assertEqual(len(result.traversal_order), 0)
+
+    def test_tools_34_get_ancestors_handles_fetch_errors(self):
+        """TOOLS-34: Get ancestors handles parent fetch errors gracefully."""
+        async def mock_get_parent(issue_key, include_parent_links=True, parent_link_field="Parent Link"):
+            if issue_key == "TEST-CHILD":
+                return ParentInfo(issue_key="TEST-CHILD", parent_key="TEST-PARENT", parent_summary="Parent Summary", parent_type="subtask")
+            else:
+                return ParentInfo(issue_key="TEST-PARENT", parent_key=None, parent_summary=None, parent_type=None)
+        
+        self.tools.get_parent = mock_get_parent
+        # Make get_issue raise an exception
+        self.mock_client.get_issue.side_effect = Exception("JIRA API error")
+        
+        result = asyncio.run(self.tools.get_ancestors("TEST-CHILD"))
+        
+        # Should stop traversal on error but not crash
+        self.assertEqual(result.total_ancestors, 0)
+        self.assertEqual(len(result.ancestors), 0)
+
+    def test_tools_35_get_ancestors_prevents_cycles(self):
+        """TOOLS-35: Get ancestors prevents infinite loops from cycles."""
+        # Create a cycle: CHILD -> PARENT -> CHILD
+        async def mock_get_parent(issue_key, include_parent_links=True, parent_link_field="Parent Link"):
+            cycle_map = {
+                "TEST-CHILD": ParentInfo(issue_key="TEST-CHILD", parent_key="TEST-PARENT", parent_summary="Parent Summary", parent_type="subtask"),
+                "TEST-PARENT": ParentInfo(issue_key="TEST-PARENT", parent_key="TEST-CHILD", parent_summary="Child Summary", parent_type="subtask")
+            }
+            return cycle_map.get(issue_key, ParentInfo(issue_key=issue_key, parent_key=None, parent_summary=None, parent_type=None))
+        
+        self.tools.get_parent = mock_get_parent
+        self.mock_client.get_issue.return_value = {
+            "fields": {"summary": "Parent Summary", "status": {"name": "Open"}}
+        }
+        
+        result = asyncio.run(self.tools.get_ancestors("TEST-CHILD"))
+        
+        # Should only traverse once and stop when hitting visited issue
+        self.assertEqual(result.total_ancestors, 1)
+        self.assertEqual(result.ancestors[0].key, "TEST-PARENT")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Implement relationship tools including:
- get_issue_relationships: overview of all relationships
- get_descendants: find all child issues with depth control
- get_children: immediate children only
- get_linked_issues: horizontal relationships (blocks, depends)
- get_parent: immediate parent lookup
- get_ancestors: recursive parent traversal with cycle detection

Enhanced tool descriptions for better LLM guidance and updated server instructions with workflow recommendations.

Resolves #16

Assisted-by: Cursor (Claude)