### PR TITLE
Implement dynamic JIRA parent field discovery with TTL caching

### DIFF
--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -57,6 +57,16 @@ This document maps 1:1 to unit tests in the codebase. Each test item corresponds
 | TOOLS-33 | Get ancestors for issue with no parents | |
 | TOOLS-34 | Get ancestors handles parent fetch errors gracefully | |
 | TOOLS-35 | Get ancestors prevents infinite loops from cycles | |
+| TOOLS-36 | Dynamic field discovery via editmeta API | |
+| TOOLS-37 | TTL cache stores and retrieves field mappings | |
+| TOOLS-38 | TTL cache expires entries after configured timeout | |
+| TOOLS-39 | Get parent uses discovered fields before fallback | |
+| TOOLS-40 | Get parent fallback when editmeta fails | |
+| TOOLS-41 | Get parent chooses first field when multiple have values | |
+| TOOLS-42 | Field discovery handles missing project/issue type | |
+| TOOLS-43 | Field discovery identifies Epic Link schema type | |
+| TOOLS-44 | Field discovery identifies Parent Link schema type | |
+| TOOLS-45 | Get ancestors with dynamic field discovery | |
 
 ## SERVER - MCP Server Creation and Configuration
 

--- a/example_mcp_jira_server.yaml
+++ b/example_mcp_jira_server.yaml
@@ -1,6 +1,9 @@
 # Test configuration for Red Hat JIRA
 url: https://issues.redhat.com
 
+# TTL is 1 hour by default
+field_cache_ttl: 3600
+
 # No authentication needed for public issues on Red Hat JIRA
 # username: your_username
 # password: your_password  

--- a/mcp_jira_server/config.py
+++ b/mcp_jira_server/config.py
@@ -18,6 +18,7 @@ username: myuser            # for password or token auth
 password: mypass            # basic auth
 token: myapitoken           # basic auth (with username)
 bearer_token: abc123        # Personal Access Token (no username needed)
+field_cache_ttl: 3600       # TTL for field discovery cache in seconds (default: 3600 = 1 hour)
 ```
 """
 

--- a/mcp_jira_server/test_cli.py
+++ b/mcp_jira_server/test_cli.py
@@ -64,7 +64,8 @@ class TestCLI(unittest.TestCase):
             username="cliuser",
             password="clipass",
             token="clitoken",
-            bearer_token="clibearer"
+            bearer_token="clibearer",
+            field_cache_ttl=3600
         )
 
     @patch("mcp_jira_server.server.load_config")
@@ -136,7 +137,8 @@ class TestCLI(unittest.TestCase):
             username="overrideuser",         # CLI overrides config
             password=None,
             token="configtoken",             # Config value used
-            bearer_token=None
+            bearer_token=None,
+            field_cache_ttl=3600
         )
 
     @patch("mcp_jira_server.server.load_config")

--- a/mcp_jira_server/test_tools.py
+++ b/mcp_jira_server/test_tools.py
@@ -6,7 +6,7 @@ functionality including search_issues, get_issue, and identifier_hint.
 """
 
 import unittest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 import asyncio
 
 # Import modules under test  
@@ -703,6 +703,299 @@ class TestTools(unittest.TestCase):
         result = asyncio.run(self.tools.get_ancestors("TEST-CHILD"))
         
         # Should only traverse once and stop when hitting visited issue
+        self.assertEqual(result.total_ancestors, 1)
+        self.assertEqual(result.ancestors[0].key, "TEST-PARENT")
+
+    def test_tools_36_dynamic_field_discovery_via_editmeta_api(self):
+        """TOOLS-36: Dynamic field discovery via editmeta API."""
+        # Mock editmeta response with Epic Link field
+        editmeta_response = {
+            "fields": {
+                "customfield_12311140": {
+                    "name": "Epic Link",
+                    "schema": {"custom": "com.pyxis.greenhopper.jira:gh-epic-link"}
+                },
+                "customfield_12345": {
+                    "name": "Some Other Field", 
+                    "schema": {"custom": "com.example:other"}
+                }
+            }
+        }
+        
+        self.mock_client._make_api_request.return_value = editmeta_response
+        
+        # Test field discovery
+        parent_fields = self.tools._get_parent_fields_for_issue("TEST-123", "TEST", "Story")
+        
+        # Should find the Epic Link field
+        self.assertEqual(parent_fields, ["customfield_12311140"])
+        
+        # Verify API was called correctly  
+        expected_url = "https://test.jira.com/rest/api/issue/TEST-123/editmeta"
+        self.mock_client._make_api_request.assert_called_with(expected_url, resource_name="editmeta")
+
+    def test_tools_37_ttl_cache_stores_and_retrieves_field_mappings(self):
+        """TOOLS-37: TTL cache stores and retrieves field mappings."""
+        # Mock editmeta response
+        editmeta_response = {
+            "fields": {
+                "customfield_12311140": {
+                    "name": "Epic Link",
+                    "schema": {"custom": "com.pyxis.greenhopper.jira:gh-epic-link"}
+                }
+            }
+        }
+        self.mock_client._make_api_request.return_value = editmeta_response
+        
+        # First call should hit the API
+        result1 = self.tools._get_parent_fields_for_issue("TEST-123", "TEST", "Story")
+        self.assertEqual(result1, ["customfield_12311140"])
+        self.assertEqual(self.mock_client._make_api_request.call_count, 1)
+        
+        # Second call should use cache
+        result2 = self.tools._get_parent_fields_for_issue("TEST-123", "TEST", "Story")
+        self.assertEqual(result2, ["customfield_12311140"])
+        # Should still be 1 call (cached)
+        self.assertEqual(self.mock_client._make_api_request.call_count, 1)
+
+    def test_tools_38_ttl_cache_expires_entries_after_configured_timeout(self):
+        """TOOLS-38: TTL cache expires entries after configured timeout."""
+        import time
+        
+        # Create tools with very short TTL (0.1 seconds)
+        short_ttl_tools = JiraTools(self.mock_client, field_cache_ttl=0.1)
+        
+        editmeta_response = {
+            "fields": {
+                "customfield_12311140": {
+                    "name": "Epic Link", 
+                    "schema": {"custom": "com.pyxis.greenhopper.jira:gh-epic-link"}
+                }
+            }
+        }
+        self.mock_client._make_api_request.return_value = editmeta_response
+        
+        # First call
+        result1 = short_ttl_tools._get_parent_fields_for_issue("TEST-123", "TEST", "Story")
+        self.assertEqual(result1, ["customfield_12311140"])
+        self.assertEqual(self.mock_client._make_api_request.call_count, 1)
+        
+        # Wait for cache to expire
+        time.sleep(0.2)
+        
+        # Cache should be expired, API called again
+        result2 = short_ttl_tools._get_parent_fields_for_issue("TEST-123", "TEST", "Story")
+        self.assertEqual(result2, ["customfield_12311140"])
+        self.assertEqual(self.mock_client._make_api_request.call_count, 2)
+
+    def test_tools_39_get_parent_uses_discovered_fields_before_fallback(self):
+        """TOOLS-39: Get parent uses discovered fields before fallback."""
+        # Mock issue with project and issuetype
+        issue_data = {
+            "fields": {
+                "project": {"key": "TEST"},
+                "issuetype": {"name": "Story"},
+                "customfield_12311140": "TEST-PARENT"
+            }
+        }
+        
+        # Mock editmeta response
+        editmeta_response = {
+            "fields": {
+                "customfield_12311140": {
+                    "name": "Epic Link",
+                    "schema": {"custom": "com.pyxis.greenhopper.jira:gh-epic-link"}
+                }
+            }
+        }
+        
+        parent_data = {"fields": {"summary": "Parent Summary"}}
+        
+        self.mock_client.get_issue.side_effect = [issue_data, parent_data]
+        self.mock_client._make_api_request.return_value = editmeta_response
+        
+        result = asyncio.run(self.tools.get_parent("TEST-CHILD"))
+        
+        # Should find parent using discovered field
+        self.assertEqual(result.parent_key, "TEST-PARENT")
+        self.assertEqual(result.parent_type, "parent_field(customfield_12311140)")
+        
+        # Should NOT call get_field_by_name (fallback)
+        self.mock_client.get_field_by_name.assert_not_called()
+
+    def test_tools_40_get_parent_fallback_when_editmeta_fails(self):
+        """TOOLS-40: Get parent fallback when editmeta fails."""
+        # Mock issue data
+        issue_data = {
+            "fields": {
+                "project": {"key": "TEST"},
+                "issuetype": {"name": "Story"},
+                "customfield_12345": "TEST-PARENT"
+            }
+        }
+        
+        parent_data = {"fields": {"summary": "Parent Summary"}}
+        
+        # Make editmeta API fail
+        self.mock_client._make_api_request.side_effect = Exception("API Error")
+        self.mock_client.get_issue.side_effect = [issue_data, parent_data]
+        self.mock_client.get_field_by_name.return_value = {"id": "customfield_12345"}
+        
+        result = asyncio.run(self.tools.get_parent("TEST-CHILD", parent_link_field="Epic Link"))
+        
+        # Should find parent using fallback method
+        self.assertEqual(result.parent_key, "TEST-PARENT")
+        self.assertEqual(result.parent_type, "parent_link(Epic Link)")
+        
+        # Should call fallback method
+        self.mock_client.get_field_by_name.assert_called_with("Epic Link")
+
+    def test_tools_41_get_parent_chooses_first_field_when_multiple_have_values(self):
+        """TOOLS-41: Get parent chooses first field when multiple have values."""
+        # Mock issue with BOTH parent fields having values
+        issue_data = {
+            "fields": {
+                "project": {"key": "TEST"},
+                "issuetype": {"name": "Epic"},
+                "customfield_12311140": "TEST-EPIC",      # Epic Link has value
+                "customfield_12313140": "TEST-PARENT"     # Parent Link ALSO has value
+            }
+        }
+        
+        # Mock editmeta response with both field types
+        editmeta_response = {
+            "fields": {
+                "customfield_12311140": {
+                    "name": "Epic Link",
+                    "schema": {"custom": "com.pyxis.greenhopper.jira:gh-epic-link"}
+                },
+                "customfield_12313140": {
+                    "name": "Parent Link",
+                    "schema": {"custom": "com.atlassian.jpo:jpo-custom-field-parent"}
+                }
+            }
+        }
+        
+        parent_data = {"fields": {"summary": "Epic Summary"}}
+        
+        self.mock_client.get_issue.side_effect = [issue_data, parent_data]
+        self.mock_client._make_api_request.return_value = editmeta_response
+        
+        result = asyncio.run(self.tools.get_parent("TEST-CHILD"))
+        
+        # Should use Epic Link (first discovered) and ignore Parent Link
+        self.assertEqual(result.parent_key, "TEST-EPIC")
+        self.assertEqual(result.parent_type, "parent_field(customfield_12311140)")
+
+    def test_tools_42_field_discovery_handles_missing_project_issue_type(self):
+        """TOOLS-42: Field discovery handles missing project/issue type."""
+        # Mock issue without project/issuetype fields
+        issue_data = {
+            "fields": {
+                "customfield_12345": "TEST-PARENT"
+            }
+        }
+        
+        parent_data = {"fields": {"summary": "Parent Summary"}}
+        
+        self.mock_client.get_issue.side_effect = [issue_data, parent_data]
+        self.mock_client.get_field_by_name.return_value = {"id": "customfield_12345"}
+        
+        result = asyncio.run(self.tools.get_parent("TEST-CHILD", parent_link_field="Epic Link"))
+        
+        # Should skip dynamic discovery and use fallback
+        self.assertEqual(result.parent_key, "TEST-PARENT")
+        self.assertEqual(result.parent_type, "parent_link(Epic Link)")
+        
+        # Should not call editmeta API
+        self.mock_client._make_api_request.assert_not_called()
+
+    def test_tools_43_field_discovery_identifies_epic_link_schema_type(self):
+        """TOOLS-43: Field discovery identifies Epic Link schema type."""
+        editmeta_response = {
+            "fields": {
+                "customfield_12311140": {
+                    "name": "Epic Link",
+                    "schema": {"custom": "com.pyxis.greenhopper.jira:gh-epic-link"}
+                },
+                "customfield_99999": {
+                    "name": "Other Field",
+                    "schema": {"custom": "com.example:other-type"}
+                }
+            }
+        }
+        
+        self.mock_client._make_api_request.return_value = editmeta_response
+        
+        result = self.tools._get_parent_fields_for_issue("TEST-123", "TEST", "Story")
+        
+        # Should only find Epic Link field
+        self.assertEqual(result, ["customfield_12311140"])
+
+    def test_tools_44_field_discovery_identifies_parent_link_schema_type(self):
+        """TOOLS-44: Field discovery identifies Parent Link schema type."""
+        editmeta_response = {
+            "fields": {
+                "customfield_12313140": {
+                    "name": "Parent Link",
+                    "schema": {"custom": "com.atlassian.jpo:jpo-custom-field-parent"}
+                },
+                "customfield_99999": {
+                    "name": "Other Field",
+                    "schema": {"custom": "com.example:other-type"}
+                }
+            }
+        }
+        
+        self.mock_client._make_api_request.return_value = editmeta_response
+        
+        result = self.tools._get_parent_fields_for_issue("TEST-123", "TEST", "Epic")
+        
+        # Should only find Parent Link field
+        self.assertEqual(result, ["customfield_12313140"])
+
+    def test_tools_45_get_ancestors_with_dynamic_field_discovery(self):
+        """TOOLS-45: Get ancestors with dynamic field discovery."""
+        # Mock get_parent calls directly since ancestors just calls get_parent repeatedly
+        async def mock_get_parent(issue_key, include_parent_links=True, parent_link_field="Parent Link"):
+            if issue_key == "TEST-CHILD":
+                return ParentInfo(
+                    issue_key="TEST-CHILD",
+                    parent_key="TEST-PARENT",
+                    parent_summary="Parent Summary",
+                    parent_type="parent_field(customfield_12311140)"
+                )
+            elif issue_key == "TEST-PARENT":
+                return ParentInfo(
+                    issue_key="TEST-PARENT", 
+                    parent_key=None,
+                    parent_summary=None,
+                    parent_type=None
+                )
+            return ParentInfo(issue_key=issue_key, parent_key=None, parent_summary=None, parent_type=None)
+        
+        # Mock the get_issue calls that ancestors uses for creating IssueSummary objects
+        def mock_get_issue(issue_key, expand=None):
+            if issue_key == "TEST-PARENT":
+                return {
+                    "key": "TEST-PARENT",
+                    "fields": {
+                        "summary": "Parent Summary",
+                        "status": {"name": "Open"}
+                    }
+                }
+            return {
+                "key": issue_key,
+                "fields": {"summary": "Default Summary", "status": {"name": "Open"}}
+            }
+        
+        self.mock_client.get_issue.side_effect = mock_get_issue
+        
+        # Patch get_parent to use our mock
+        with patch.object(self.tools, 'get_parent', side_effect=mock_get_parent):
+            result = asyncio.run(self.tools.get_ancestors("TEST-CHILD"))
+        
+        # Should find ancestors using dynamic discovery
         self.assertEqual(result.total_ancestors, 1)
         self.assertEqual(result.ancestors[0].key, "TEST-PARENT")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,7 @@ PyYAML==6.0.1
 urllib3==2.1.0
 
 # MCP server implementation
-mcp[cli]==1.9.3 
+mcp[cli]==1.9.3
+
+# TTL cache for field discovery
+cachetools==5.3.2 


### PR DESCRIPTION
- Add dynamic field discovery via editmeta API to identify parent-related custom fields based on schema types (Epic Link, Parent Link)
- Implement TTL cache for discovered field mappings per project/issue type
- Update get_parent to use discovered fields before fallback to field names
- Fix ancestor traversal to work across different JIRA issue types
- Add test coverage for new functionality
- Add cachetools dependency for TTL cache implementation

Resolves issue where ancestor lookup failed due to hardcoded field assumptions.

Assisted-by: Cursor (Claude)